### PR TITLE
Update phone number validation to 3 to 15 digits

### DIFF
--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -13,7 +13,14 @@ public class Phone {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Singapore phone numbers should only contain 8 digit numbers";
-    public static final String VALIDATION_REGEX = "\\d{8}";
+    /*
+        * The phone number must be between 3 and 15 digits long.
+        * Shortcodes are usually 3 to 5 digits long.
+        * International numbers are usually up to 15 digits long by ITU-T E.164 standard.
+        * Thus, we set the minimum length to 3 and maximum length to 15.
+        * The phone number should only contain digits.
+     */
+    public static final String VALIDATION_REGEX = "\\d{3,15}";
     public final String value;
 
     /**

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -31,12 +31,15 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
-        assertFalse(Phone.isValidPhone("911")); // exactly 3 numbers
-        assertFalse(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertFalse(Phone.isValidPhone("91")); // exactly 2 numbers
         assertFalse(Phone.isValidPhone("一二三四五六七八")); // non-ascii characters
+        assertFalse(Phone.isValidPhone("1234567890123456")); // exactly 16 numbers
 
         // valid phone numbers
-        assertTrue(Phone.isValidPhone("93121534"));
+        assertTrue(Phone.isValidPhone("93121534")); // exactly 8 numbers (Singapore number)
+        assertTrue(Phone.isValidPhone("6593121534")); // exactly 10 numbers (Singapore number with country code)
+        assertTrue(Phone.isValidPhone("999")); // exactly 3 numbers
+        assertTrue(Phone.isValidPhone("123456789012345")); // exactly 15 numbers
     }
 
     @Test


### PR DESCRIPTION
Fix #58 

New validation rule: Phone number must be 3 to 15 digits only

Reasoning:

- Lower bound (3 digits):

  - Some valid phone numbers (e.g., short codes, emergency, or service numbers) can be as short as 3 digits.

  - This allows flexibility for such cases while still preventing invalid 1–2 digit inputs.

- Upper bound (15 digits):

  - According to the E.164 international telephone numbering plan (ITU-T standard), the maximum number of digits in a complete international phone number is 15 digits, excluding the “+” sign.

  - This ensures our system remains globally compatible.

Benefits:

- Supports both local and international phone numbers.

- Complies with E.164 global standard.

- Improves user experience by preventing unnecessary validation errors.