### PR TITLE
Fix trying to access parent when at root folder

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -67,9 +67,10 @@ public class LogicManager implements Logic {
             logger.severe("Could not save data to file due to insufficient permission: " + filePath);
 
             // check permission of filePath
-            Path parentPath = filePath.getParent();
-            if (((filePath != null) && !Files.isWritable(filePath))
-                    || ((parentPath != null) && !Files.isWritable(parentPath))) {
+            Path parentPath = (filePath != null) ? filePath.getParent() : null;
+            boolean isParentPathNotWritable = (parentPath != null) && !Files.isWritable(parentPath);
+            boolean isFilePathNotWritable = (filePath != null) && !Files.isWritable(filePath);
+            if (isParentPathNotWritable || isFilePathNotWritable) {
                 throw new CommandException(
                         String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, filePath), ioe);
             }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -105,8 +105,12 @@ public class LogicManagerTest {
                 LogicManager.FILE_OPS_ERROR_FORMAT, DUMMY_IO_EXCEPTION.getMessage()));
 
         prefPath.toFile().delete();
+    }
 
-        // when path is null
+
+    @Test
+    public void execute_storageOnNullPath_throwsCommandException() {
+        // Simulate IOException during storage save and file accessible
         assertCommandFailureForExceptionFromStorage(DUMMY_IO_EXCEPTION, String.format(
                 LogicManager.FILE_OPS_ERROR_FORMAT, DUMMY_IO_EXCEPTION.getMessage()), null);
     }


### PR DESCRIPTION
Fix #269 

Bug caused when trying to the parent of file, but the parent may not exist.
Also added proof when the filePath is null.
Added skip the check if it does not exist.